### PR TITLE
ErrorHandlingAzureConnections

### DIFF
--- a/src/SQLChecks/Functions/Public/AzureDBFunctions/New-AzureSQLDbConnectionWithCert.ps1
+++ b/src/SQLChecks/Functions/Public/AzureDBFunctions/New-AzureSQLDbConnectionWithCert.ps1
@@ -67,6 +67,6 @@ Function New-AzureSQLDbConnectionWithCert {
     catch {
         Write-Error "Failed to create connection to Azure DB Server: $AzureSQLDBServerName"
         Write-Error "Error Message: $_.Exception.Message"
-        return
+        throw
     }
 }

--- a/src/SQLChecks/Functions/Public/Get-DatabaseFilesOverMaxDataFileSpaceUsed.ps1
+++ b/src/SQLChecks/Functions/Public/Get-DatabaseFilesOverMaxDataFileSpaceUsed.ps1
@@ -105,6 +105,8 @@ and     c.SpaceUsed > $MaxDataFileSpaceUsedPercent
                 $conn.Close()
 
             }
+
+            throw
         }
     
     }

--- a/src/SQLChecks/Functions/Public/Get-DuplicateIndexes.ps1
+++ b/src/SQLChecks/Functions/Public/Get-DuplicateIndexes.ps1
@@ -245,6 +245,8 @@ FROM    #tempResults AS tr;
         $conn.Close()
 
       }
+
+      throw
     }
   
   }


### PR DESCRIPTION
Some errors are swallowed and the checks actually come back clean (especially in cases where returning 0 rows is a passed check). Adding the throw fails the check in pester