### PR TITLE
RemoveTimeout_GetDatabasesToCheck

### DIFF
--- a/src/SQLChecks/Functions/Public/Get-DatabasesToCheck.ps1
+++ b/src/SQLChecks/Functions/Public/Get-DatabasesToCheck.ps1
@@ -54,7 +54,7 @@ where d.state_desc = 'ONLINE'
     }
 
     $queryResults = Get-CachedScriptBlockResult -Key $serverInstance -ScriptBlock {
-        Invoke-Sqlcmd -ServerInstance $serverInstance -query $query -QueryTimeout 60
+        Invoke-Sqlcmd -ServerInstance $serverInstance -query $query -QueryTimeout 0
     }
 
     $queryResults | Sort-Object -Property DatabaseName | ForEach-Object {


### PR DESCRIPTION
The GetDatabasesToCheck query sometimes takes 2 - 3 minutes to run on certain environments. If this query doesn't return, the error never surfaces as a failed check (checks don't even run)