### PR TITLE
Update Get-IdentityColumnLimit.ps1

### DIFF
--- a/src/SQLChecks/Functions/Public/Get-IdentityColumnLimit.ps1
+++ b/src/SQLChecks/Functions/Public/Get-IdentityColumnLimit.ps1
@@ -88,7 +88,7 @@ select tr.DatabaseName,
        tr.NoRows 
 from   #tempResults AS tr
 cross apply (select Case 
-					when tr.LastValue < 0 Then (tr.MaxValue+ cast(tr.LastValue as decimal(19,2)))/tr.MaxValue /*Assumes maxes out at zero*/
+					when tr.LastValue < 0 Then (tr.MaxValue+tr.LastValue)/TRY_CONVERT(decimal(21,2),tr.MaxValue)/2 /*Assumes maxes out at cap, not zero*/
 					else  cast(tr.LastValue as decimal(19,2))  / tr.MaxValue
 			end * 100    as [PercentageFull]) x
 


### PR DESCRIPTION
Default assumption is now that an identity column with a negative value can increment up to max, not just to zero.